### PR TITLE
Error if compatibility.json is too small

### DIFF
--- a/.github/workflows/compat2patch.yml
+++ b/.github/workflows/compat2patch.yml
@@ -22,8 +22,8 @@ jobs:
           compatibility_json=compatibility.json
           original_sha256=$(jq -r .sha256 $compatibility_json)
           curl -sSfLo $compatibility_json "https://rpcs3.net/compatibility?patch&api=v1&v=1.2"
-         min_size = 25
-         if [ $(stat -c %s $compatibility_json) -le $min_size ]; then 
+          min_size_bytes = 10000 # 10 Kilobytes
+          if [ $(stat -c %s $compatibility_json) -le $min_size_bytes ]; then 
             echo "::error::$compatibility_json is too small."
             exit 1
           fi

--- a/.github/workflows/compat2patch.yml
+++ b/.github/workflows/compat2patch.yml
@@ -19,13 +19,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Check for update
         run: |
-          original_sha256=$(jq -r .sha256 compatibility.json)
-          curl -sSfLo compatibility.json "https://rpcs3.net/compatibility?patch&api=v1&v=1.2"
-          if [ $original_sha256 != $(jq -r .sha256 compatibility.json) ]; then
-            jq -r .patch compatibility.json > patch.yml
+          compatibility_json=compatibility.json
+          original_sha256=$(jq -r .sha256 $compatibility_json)
+          curl -sSfLo $compatibility_json "https://rpcs3.net/compatibility?patch&api=v1&v=1.2"
+          if [ $(stat -c %s $compatibility_json) -le 25 ]; then 
+            echo "::error::$compatibility_json is too small."
+            exit 1
+          fi
+          if [ $original_sha256 != $(jq -r .sha256 $compatibility_json) ]; then
+            jq -r .patch $compatibility_json > patch.yml
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git config user.name "github-actions[bot]"
-            git add patch.yml compatibility.json
+            git add patch.yml $compatibility_json
             time=$(date '+%Y-%m-%d %H:%M:%S %A (%Z %z)')
             msg="Update patch from remote - \`${time}\`"
             echo "$msg"

--- a/.github/workflows/compat2patch.yml
+++ b/.github/workflows/compat2patch.yml
@@ -22,7 +22,8 @@ jobs:
           compatibility_json=compatibility.json
           original_sha256=$(jq -r .sha256 $compatibility_json)
           curl -sSfLo $compatibility_json "https://rpcs3.net/compatibility?patch&api=v1&v=1.2"
-          if [ $(stat -c %s $compatibility_json) -le 25 ]; then 
+         min_size = 25
+         if [ $(stat -c %s $compatibility_json) -le $min_size ]; then 
             echo "::error::$compatibility_json is too small."
             exit 1
           fi

--- a/.github/workflows/compat2patch.yml
+++ b/.github/workflows/compat2patch.yml
@@ -22,7 +22,7 @@ jobs:
           compatibility_json=compatibility.json
           original_sha256=$(jq -r .sha256 $compatibility_json)
           curl -sSfLo $compatibility_json "https://rpcs3.net/compatibility?patch&api=v1&v=1.2"
-          min_size_bytes = 10000 # 10 Kilobytes
+          min_size_bytes=10240 # 10 Kilobytes
           if [ $(stat -c %s $compatibility_json) -le $min_size_bytes ]; then 
             echo "::error::$compatibility_json is too small."
             exit 1


### PR DESCRIPTION
This should stop those weird commits that wipe both files.